### PR TITLE
[Refactor] PEP8 compatibility

### DIFF
--- a/pyfancy/pyfancy.py
+++ b/pyfancy/pyfancy.py
@@ -1,7 +1,7 @@
 # Provides methods for manipulating text styling in specific terminals.
 # Uses a basic chaining method where text properties are added by calling
 # methods with related names.
-# 
+#
 # For example, to print "Hello, world!" in red:
 #   print pyfancy().red("Hello, world!").get()
 #
@@ -16,99 +16,104 @@
 # direct access to the string object called "out". However, accessing this
 # object will not reset the style, so any text outputted after will have
 # the same style as whatever the text was at the end of the chain.
-# 
+#
 # The get() method is better for accessing text because it resets the text
 # style so no new text will have unwanted styling.
 
+
 class pyfancy:
+
     def __str__(self): return self.get()
-    def __init__(self, parseText="", obj=""):
+
+    def __init__(self, parseText='', obj=''):
         # Stores output text, for reset use get()
         self.out = str(obj)
         self.parseText = str(parseText)
-        if (self.parseText != ""):
+        if (self.parseText != ''):
             self.parse(self.parseText)
 
-    codes = { # The different escape codes
-        'raw':              0,
-        'bold':             1,
-        'dim':              2,
-        'underlined':       4,
-        'blinking':         5,
-        'inverted':         7,
-        'hidden':           8,
-        'black':           30,
-        'red':             31,
-        'green':           32,
-        'yellow':          33,
-        'blue':            34,
-        'magenta':         35,
-        'cyan':            36,
-        'light_gray':      37,
-        'black_bg':        40,
-        'red_bg':          41,
-        'green_bg':        42,
-        'yellow_bg':       43,
-        'blue_bg':         44,
-        'purple_bg':       45,
-        'cyan_bg':         46,
-        'gray_bg':         47,
-        'dark_gray':       90,
-        'light_red':       91,
-        'light_green':     92,
-        'light_yellow':    93,
-        'light_blue':      94,
-        'light_magenta':   95,
-        'light_cyan':      96,
-        'white':           97,
-        'dark_gray_bg':    100,
-        'light_red_bg':    101,
-        'light_green_bg':  102,
+    codes = {  # The different escape codes
+        'raw': 0,
+        'bold': 1,
+        'dim': 2,
+        'underlined': 4,
+        'blinking': 5,
+        'inverted': 7,
+        'hidden': 8,
+        'black': 30,
+        'red': 31,
+        'green': 32,
+        'yellow': 33,
+        'blue': 34,
+        'magenta': 35,
+        'cyan': 36,
+        'light_gray': 37,
+        'black_bg': 40,
+        'red_bg': 41,
+        'green_bg': 42,
+        'yellow_bg': 43,
+        'blue_bg': 44,
+        'purple_bg': 45,
+        'cyan_bg': 46,
+        'gray_bg': 47,
+        'dark_gray': 90,
+        'light_red': 91,
+        'light_green': 92,
+        'light_yellow': 93,
+        'light_blue': 94,
+        'light_magenta': 95,
+        'light_cyan': 96,
+        'white': 97,
+        'dark_gray_bg': 100,
+        'light_red_bg': 101,
+        'light_green_bg': 102,
         'light_yellow_bg': 103,
-        'light_blue_bg':   104,
+        'light_blue_bg': 104,
         'light_purple_bg': 105,
-        'light_cyan_bg':   106,
-        'white_bg':        107
+        'light_cyan_bg': 106,
+        'white_bg': 107
     }
 
     # Stores output text, for reset use get()
-    out = ""
+    out = ''
 
     # Returns output text and resets properties
     def get(self):
-        return self.out + "\033[0m"
+        return self.out + '\033[0m'
 
     # Outputs text using print (should work in Python 2 and 3)
     def output(self):
         print(self.get())
 
     # Adds new text without changing the styling
-    def add(self,addition):
-        self.out += addition;
+    def add(self, addition):
+        self.out += addition
         return self
-    
-    def read(self,file):
+
+    def read(self, file):
         f = open(file, 'r')
         self.out += f.read()
         f.close()
         return self
-    
+
     def reset(self):
-        self.out = ""
+        self.out = ''
         return self
-      
-    #Alternate between all the colours of the rainbow
-    #No orange, replaced with lightRed
-    #No purple/violet so I ignored it
-    def rainbow(self,addition=""):
+
+    # Alternate between all the colours of the rainbow
+    # No orange, replaced with lightRed
+    # No purple/violet so I ignored it
+    def rainbow(self, addition=''):
         x = 0
-        for i in range(len(addition)): 
-            if (addition[i] in [" ", "\t", "\n", "\r"]): x+=1
-            [self.red, self.light_red, self.yellow, self.green, self.light_blue, self.blue][(i-x) % 6](addition[i])
+        for i in range(len(addition)):
+            if (addition[i] in [' ', '\t', '\n', '\r']):
+                x += 1
+            [self.red, self.light_red, self.yellow, self.green,
+                self.light_blue, self.blue][(i - x) % 6](addition[i])
         return self
-    
+
     def strip(self):
-        text = ""
+        text = ''
         i = 0
         while i < len(self.out):
             if self.out[i] == '\033':
@@ -125,37 +130,37 @@ class pyfancy:
             text += self.out[i]
             i += 1
         return text
-    
+
     # Simply apply the attribute with the given name
-    def attr(self,name):
+    def attr(self, name):
         if name in self.codes:
-            self.out += "\033[%dm" % self.codes[name]
+            self.out += '\033[%dm' % self.codes[name]
 
     # Parses text and automatically assigns attributes
     # Attributes are specified through brackets
     # For example, .parse("{red Hello}") is the same as .red("Hello")
     # Multiple attributes can be specified by commas, eg {red,bold Hello}
     # Brackets can be nested, eg {red Hello, {bold world}!}
-    # Brackets can be escaped with backslashes 
-    def parse(self,text):
-        i = 0 # Current index
-        props = [] # Property stack; required for nested brackets
+    # Brackets can be escaped with backslashes
+    def parse(self, text):
+        i = 0  # Current index
+        props = []  # Property stack; required for nested brackets
         while i < len(text):
             c = text[i]
-            if c == '\\': # Escape character
+            if c == '\\':  # Escape character
                 i += 1
                 if i < len(text):
                     self.out += text[i]
-            elif c == '{': # New property list
-                prop = '' # Current property
+            elif c == '{':  # New property list
+                prop = ''  # Current property
                 i += 1
-                curprops = [] # Properties that are part of this bracket
+                curprops = []  # Properties that are part of this bracket
                 while text[i] != ' ':
                     if i + 1 == len(text):
                         return self
                     if text[i] == ',':
                         # Properties separated by commas
-                        self.attr(prop);
+                        self.attr(prop)
                         curprops.append(prop)
                         prop = ''
                         i += 1
@@ -179,26 +184,30 @@ class pyfancy:
                 self.out += c
             i += 1
         return self
-                        
 
     # Multicolored text
-    def multi(self,string):
-        i = 31 # ID of escape code; starts at 31 (red) and goes to 36 (cyan)
-        for c in string: # Iterate through string
-            self.out += "\033[" + str(i) + "m" + c
-            i += 1 # Why u no have ++i? >:(
-            if(i > 36): i = 31
+    def multi(self, string):
+        i = 31  # ID of escape code; starts at 31 (red) and goes to 36 (cyan)
+        for c in string:  # Iterate through string
+            self.out += '\033[' + str(i) + 'm' + c
+            i += 1  # Why u no have ++i? >:(
+            if(i > 36):
+                i = 31
         return self
 
-# Adds a formatting function to pyfancy with the specified name and formatting code
+# Adds a formatting function to pyfancy with the specified name
+# and formatting code
 # This shouldn't be exported
-def _add(name,number):
-    def inner(self, addition = ""):
-        self.out += "\033[%dm%s" % (number, addition)
+
+
+def _add(name, number):
+    def inner(self, addition=''):
+        self.out += '\033[%dm%s' % (number, addition)
         return self
-    setattr(pyfancy,name,inner)
+    setattr(pyfancy, name, inner)
+
 
 # Generate all default color / format codes
 for item in pyfancy.codes.items():
-    if len(item) > 1: # Just in case
-        _add(item[0],item[1])
+    if len(item) > 1:  # Just in case
+        _add(item[0], item[1])


### PR DESCRIPTION
### 1. Behavior before pull request

```shell
D:\Pyfancy-2\pyfancy>flake8 pyfancy.py
pyfancy.py:4:2: W291 trailing whitespace
pyfancy.py:19:2: W291 trailing whitespace
pyfancy.py:23:1: E302 expected 2 blank lines, found 1
pyfancy.py:25:5: E301 expected 1 blank line, found 0
pyfancy.py:32:14: E261 at least two spaces before inline comment
pyfancy.py:86:17: E231 missing whitespace after ','
pyfancy.py:87:29: E703 statement ends with a semicolon
pyfancy.py:89:1: W293 blank line contains whitespace
pyfancy.py:90:18: E231 missing whitespace after ','
pyfancy.py:95:1: W293 blank line contains whitespace
pyfancy.py:99:1: W293 blank line contains whitespace
pyfancy.py:100:5: E265 block comment should start with '# '
pyfancy.py:101:5: E265 block comment should start with '# '
pyfancy.py:102:5: E265 block comment should start with '# '
pyfancy.py:103:21: E231 missing whitespace after ','
pyfancy.py:105:39: W291 trailing whitespace
pyfancy.py:106:56: E701 multiple statements on one line (colon)
pyfancy.py:106:59: E225 missing whitespace around operator
pyfancy.py:107:80: E501 line too long (115 > 79 characters)
pyfancy.py:109:1: W293 blank line contains whitespace
pyfancy.py:128:1: W293 blank line contains whitespace
pyfancy.py:130:18: E231 missing whitespace after ','
pyfancy.py:139:47: W291 trailing whitespace
pyfancy.py:140:19: E231 missing whitespace after ','
pyfancy.py:141:14: E261 at least two spaces before inline comment
pyfancy.py:142:19: E261 at least two spaces before inline comment
pyfancy.py:145:26: E261 at least two spaces before inline comment
pyfancy.py:149:27: E261 at least two spaces before inline comment
pyfancy.py:150:26: E261 at least two spaces before inline comment
pyfancy.py:152:30: E261 at least two spaces before inline comment
pyfancy.py:158:40: E703 statement ends with a semicolon
pyfancy.py:182:1: W293 blank line contains whitespace
pyfancy.py:184:5: E303 too many blank lines (2)
pyfancy.py:185:19: E231 missing whitespace after ','
pyfancy.py:186:15: E261 at least two spaces before inline comment
pyfancy.py:187:25: E261 at least two spaces before inline comment
pyfancy.py:189:19: E261 at least two spaces before inline comment
pyfancy.py:190:23: E701 multiple statements on one line (colon)
pyfancy.py:193:80: E501 line too long (83 > 79 characters)
pyfancy.py:195:1: E302 expected 2 blank lines, found 1
pyfancy.py:195:14: E231 missing whitespace after ','
pyfancy.py:196:29: E251 unexpected spaces around keyword / parameter equals
pyfancy.py:196:31: E251 unexpected spaces around keyword / parameter equals
pyfancy.py:199:20: E231 missing whitespace after ','
pyfancy.py:199:25: E231 missing whitespace after ','
pyfancy.py:202:1: E305 expected 2 blank lines after class or function definition, found 1
pyfancy.py:203:22: E261 at least two spaces before inline comment
pyfancy.py:204:21: E231 missing whitespace after ','
```

### 2. Behavior after pull request

```shell
D:\Pyfancy-2\pyfancy>flake8 pyfancy.py

D:\Pyfancy-2\pyfancy>
```

### 3. Argumentation

I edit your code, that it will be [**PEP8**](https://www.python.org/dev/peps/pep-0008/) coding style compatible.

I use [**pyformat**](https://pypi.python.org/pypi/pyformat) for it.

Thanks.