### PR TITLE
[Add] PyPI configuration files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,15 @@ language: python
 python:
   - "2.7"
   - "3.6"
-script:
+install:
+  - sudo apt-get install pandoc
   - pip install --upgrade pyformat
+  - pip install pygments
+  - pip install pypandoc
+  - pip install pyroma
+script:
   - python pyfancy/pyfancy.py
   - python pyfancy/demo.py
   - pyformat --in-place pyfancy/pyfancy.py
   - pyformat --in-place pyfancy/demo.py
+  - pyroma .

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/ilovecode1/Pyfancy-2.svg?branch=master)](https://travis-ci.org/ilovecode1/Pyfancy-2)
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Filovecode1%2FPyfancy-2.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Filovecode1%2FPyfancy-2?ref=badge_shield)
+[![FOSSA Status Shield Badge](https://app.fossa.io/api/projects/git%2Bgithub.com%2Filovecode1%2FPyfancy-2.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Filovecode1%2FPyfancy-2?ref=badge_shield)
 
 ### Download
 Go to the [releases page](https://github.com/ilovecode1/Pyfancy-2/releases) and download the latest (or previous) version.
@@ -94,7 +94,7 @@ In order to use pyfancy, import the module with `from pyfancy import *`.
 Pyfancy-2 is under the MIT license.
 
 
-[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Filovecode1%2FPyfancy-2.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Filovecode1%2FPyfancy-2?ref=badge_large)
+[![FOSSA Status Large Badge](https://app.fossa.io/api/projects/git%2Bgithub.com%2Filovecode1%2FPyfancy-2.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Filovecode1%2FPyfancy-2?ref=badge_large)
 
 ### Contributors
 

--- a/pyfancy/demo.py
+++ b/pyfancy/demo.py
@@ -1,4 +1,4 @@
-from pyfancy import *
+from pyfancy import pyfancy
 
 pyfancy().red("Hello").raw(", ").blue("world!").output()
 pyfancy().multi("Multicolored text").output()

--- a/pyfancy/pyfancy.py
+++ b/pyfancy/pyfancy.py
@@ -23,7 +23,8 @@
 
 class pyfancy:
 
-    def __str__(self): return self.get()
+    def __str__(self):
+        return self.get()
 
     def __init__(self, parseText='', obj=''):
         # Stores output text, for reset use get()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,91 @@
+# setup.cfg configuration instead of setup.py
+# https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
+[metadata]
+name = pyfancy
+description = "Simple terminal formatting in Python"
+# long_description = file: README.MD
+# Versions should comply with PEP440.  For a discussion on single-sourcing
+# the version across setup.py and the project code, see
+# https://packaging.python.org/en/latest/single_source_version.html
+version = 0.0.1
+# Author details
+author = CosmicWebServices
+author_email = andrewrodebaugh@cosmicsearch.org
+# The project's main homepage.
+url = https://github.com/ilovecode1/Pyfancy-2
+# Choose your license
+license = MIT
+# What does your project relate to?
+keywords = pyfancy ansi color colour terminal
+# See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+# How mature is this project? Common values are
+#   3 - Alpha
+#   4 - Beta
+#   5 - Production/Stable
+# Indicate who your project is intended for
+# Pick your license as you wish (should match "license" above)
+# Specify the Python versions you support here. In particular, ensure
+# that you indicate whether you support Python 2, Python 3 or both.
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    Topic :: Software Development :: Build Tools
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+
+[options]
+# Unpack your project to .egg or no?
+zip_safe = False
+# You can just specify the packages manually here if your project is
+# simple. Or you can use find.
+packages = find:
+# Alternatively, if you want to distribute just a my_module.py, uncomment
+# this:
+#   py_modules=["my_module"],
+
+# List run-time dependencies here.  These will be installed by pip when
+# your project is installed. For an analysis of "install_requires" vs pip's
+# requirements files see:
+# https://packaging.python.org/en/latest/requirements.html
+install_requires =
+   pygments
+   pypandoc
+
+[options.extras_require]
+# List additional groups of dependencies here (e.g. development
+# dependencies). You can install these using the following syntax,
+# for example:
+# $ pip install -e .[dev,test]
+# dev =
+#    check-manifest
+# test =
+#    coverage
+
+[options.entry_points]
+# To provide executable scripts, use entry points in preference to the
+# "scripts" keyword. Entry points provide cross-platform support and allow
+# pip to create the appropriate form of executable for the target platform.
+# console_scripts =
+#    sample = sample:main
+
+# [options.package_data]
+# sample = package_data.dat
+
+# [options.packages.find]
+# Exclude specific packages
+# exclude =
+#    contrib
+#    docs
+#    tests
+
+[bdist_wheel]
+# This flag says that the code is written to work on both Python 2 and Python
+# 3. If at all possible, it is good practice to do this. If you cannot, you
+# will need to generate wheels for each Python version that you support.
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,26 @@
+"""A setuptools based setup module.
+
+See:
+https://packaging.python.org/en/latest/distributing.html
+https://github.com/pypa/sampleproject
+"""
+
+# Always prefer setuptools over distutils
+from setuptools import setup
+
+# For Markdown README
+# https://stackoverflow.com/a/26737672/5951529
+try:
+    import pypandoc
+    long_description = pypandoc.convert('README.md', 'rst')
+except(IOError, ImportError):
+    long_description = open('README.md').read()
+
+setup(
+    # Although 'package_data' is the preferred approach, in some case you may
+    # need to place data files outside of your packages. See:
+    # http://docs.python.org/3.4/distutils/setupscript.html#installing-additional-files # noqa
+    # In this case, 'data_file' will be installed into '<sys.prefix>/my_data'
+    data_files=[('', ['README.md'])],
+    long_description=long_description
+)


### PR DESCRIPTION
### 1. Summary

1. I add configuration files for PyPI,
1. I fix flake8 warnings and errors.

### 2. Tests

#### 2.1. pyroma

I use [**pyroma**](https://pypi.python.org/pypi/pyroma/) for checking PyPI configuration.

See [**Travis CI result**](https://travis-ci.org/Kristinita/Pyfancy-2/jobs/330687156#L574):

```shell
0.50s$ pyroma .
------------------------------
Checking .
Found pyfancy
------------------------------
Final rating: 10/10
Your cheese is so fresh most people think it's a cream: Mascarpone
------------------------------
```

#### 2.2. Installation

I print command in console:

	pip install git+https://github.com/Kristinita/Pyfancy-2/

I create a file `SashaPyfancy.py` in any folder of my PC. Content of `SashaPyfancy.py`:

```python
from pyfancy.pyfancy import pyfancy

pyfancy().red("Hello").raw(", ").blue("world!").output()
pyfancy().multi("Multicolored text").output()
pyfancy().rainbow("Rainbow text").output()
pyfancy("{red foo {bold bar} baz}").output()
pyfancy().black_bg("Black background").output()
pyfancy().green_bg("Green background").output()
pyfancy().red_bg("Red background").output()
pyfancy().black().yellow_bg("Yellow background").output()
pyfancy().blue_bg("Blue background").output()
pyfancy().purple_bg("Purple background").output()
pyfancy().cyan_bg("Cyan background").output()
pyfancy().black().gray_bg("Gray background").output()
pyfancy().red("This should not be seen!").reset().output()
print(pyfancy().red("Hello").raw(", ").blue("world!").strip())

```

```shell
D:\Киролайна>python SashaPyfancy.py
Hello, world!
Multicolored text
Rainbow text
foo bar baz
Black background
Green background
Red background
Yellow background
Blue background
Purple background
Cyan background
Gray background

Hello, world!
```

#### 2.3. Environment

my environment:

+ Windows 10 Enterprise LTSB 64-bit EN,
+ Python 3.6.4,
+ pip 9.0.1,
+ pyroma 2.3.

### 3. Notes

#### 3.1. README.md

PyPI has problems with README.md files, see [**open issue**](https://github.com/pypa/warehouse/issues/869). I don't find easy method, how to use Markdown in Readme.

You can:

1. move pyfancy description to [**pyfancy site**](http://pyfancy2.strikingly.com/) (I think, that preferred);
1. convert Readme.md to Readme.rst, [**reStructuredText**](http://docutils.sourceforge.net/rst.html) format;
1. use Readme.md, but add dependencies: pandoc, pypandoc and pygments. I use this variant in my pull request.

#### 3.2. Comments

In `setup.cfg` I use comments from [**sampleproject**](https://github.com/pypa/sampleproject/blob/master/setup.py). You can delete them, if you want.

Thanks.
